### PR TITLE
Add pipe in output for backwards compatibility with dsm

### DIFF
--- a/fsm-lite.cpp
+++ b/fsm-lite.cpp
@@ -193,7 +193,7 @@ int main(int argc, char ** argv)
         auto s = extract(cst.csa, pos, pos + depth - 1);
         if (input_reader::smaller_than_rev_cmpl(s))
             continue;
-        cout << s;
+        cout << s + " |";
         for (size_type i = 0; i < support; ++i)
             if (config.minfreq <= rank_ep[i]-rank_sp[i])
                 cout << ' ' << ir->id(labels[i]) << ':' << rank_ep[i]-rank_sp[i];


### PR DESCRIPTION
It would be handy for reading input if the format was consistent between the version of fsm and dsm that have already been run. So if the fsm-lite output was also of the form:
AGCT | SE01:120 SE02:23
this would be great

This change puts the '|' in the output